### PR TITLE
Fix issue in CMC implementation on systems with signed chars.

### DIFF
--- a/crypto/cmc.hh
+++ b/crypto/cmc.hh
@@ -26,8 +26,8 @@ cmc_encrypt(const BlockCipher *c,
     uint8_t m[BlockCipher::blocksize];
     uint8_t carry = 0;
     for (size_t j = BlockCipher::blocksize; j != 0; j--) {
-        uint16_t a = (*ctext)[j - 1] ^
-                     (*ctext)[j - 1 + ptext.size() - BlockCipher::blocksize];
+        uint16_t a = (uint8_t)(*ctext)[j - 1] ^
+                     (uint8_t)(*ctext)[j - 1 + ptext.size() - BlockCipher::blocksize];
         m[j - 1] = carry | (uint8_t) (a << 1);
         carry = a >> 7;
     }
@@ -71,8 +71,8 @@ cmc_decrypt(const BlockCipher *c,
     uint8_t m[BlockCipher::blocksize];
     uint8_t carry = 0;
     for (size_t j = BlockCipher::blocksize; j != 0; j--) {
-        uint16_t a = (*ptext)[j - 1] ^
-                     (*ptext)[j - 1 + ctext.size() - BlockCipher::blocksize];
+        uint16_t a = (uint8_t)(*ptext)[j - 1] ^
+                     (uint8_t)(*ptext)[j - 1 + ctext.size() - BlockCipher::blocksize];
         m[j - 1] = carry | (uint8_t) (a << 1);
         carry = a >> 7;
     }


### PR DESCRIPTION
This is my first pull request on github. Hopefully I'm doing it right. 

I think I discovered an issue in your CMC implementation on platforms with signed characters.  Due to sign extension, the value that you're using for `carry` ends up being much larger than "1". My proposed solution is to cast the characters that you're pulling from `string` to `uint8_t`.

I discovered this while trying to write my own implementation of CMC in Java to play around with encrypted databases.  I could find no test vectors, so I thought I'd generate some with your code.  I couldn't get the results to match, so I tweaked your code to print out the value of `m`, which ended up having a _lot_ of `ff` in it.  (I'm using clang on OSX, but g++ on Linux appears to have similar issues.)

I know this is a fairly old project, but I thought I should let someone know.

The attached patch should fix the issue, but I presume it would break existing databases. 
